### PR TITLE
feat: Add Product Card component and related content

### DIFF
--- a/lib/src/data/design_system_data.dart
+++ b/lib/src/data/design_system_data.dart
@@ -18,6 +18,7 @@ import '../widgets/component_content/breadcrumbs_content.dart';
 import '../widgets/component_content/search_bar_content.dart';
 import '../widgets/component_content/bottom_navigation_content.dart';
 import '../widgets/component_content/tabs_content.dart';
+import '../widgets/component_content/product_card_content.dart';
 
 class DesignSystemData {
   static const List<NavigationItem> designGuides = [
@@ -202,6 +203,14 @@ class DesignSystemData {
       icon: Icons.tab,
       category: NavigationCategory.uiComponents,
       content: TabsContent(),
+    ),
+    NavigationItem.material(
+      id: 'product-card',
+      title: 'Product Card',
+      description: 'Tarjeta de producto para mostrar información básica de productos',
+      icon: Icons.shopping_bag,
+      category: NavigationCategory.uiComponents,
+      content: ProductCardContent(),
     ),
   ];
 

--- a/lib/src/widgets/component_content/product_card_content.dart
+++ b/lib/src/widgets/component_content/product_card_content.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_package_app_mayoreo/flutter_package_app_mayoreo.dart';
+import '../product_card.dart';
+
+class ProductCardContent extends StatefulWidget {
+  const ProductCardContent({super.key});
+
+  @override
+  State<ProductCardContent> createState() => _ProductCardContentState();
+}
+
+class _ProductCardContentState extends State<ProductCardContent> {
+  bool _isFavorite = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ComponentScreenTemplate(
+      componentTitle: 'Product Card',
+      componentDescription: 'Tarjeta de producto para mostrar información básica de productos en listas o grids. Incluye imagen, nombre, precio, rating, estado de favorito y opciones de comparación de descuentos.',
+      examples: [
+        ComponentExample(
+          id: 'basic',
+          title: 'Product Card Básica',
+          description: 'Tarjeta de producto con información básica y placeholder de imagen.',
+          previewWidget: _buildBasicExample(),
+          codeExample: '''
+ProductCard(
+  imageUrl: 'https://example.com/product.jpg',
+  productName: 'Producto de ejemplo',
+  price: 99.99,
+  rating: 4.5,
+  isFavorite: false,
+  onFavoriteToggle: () {
+    // Manejar toggle de favorito
+  },
+  onCompareDiscounts: () {
+    // Manejar comparación de descuentos
+  },
+  onProductTap: () {
+    // Navegar al detalle del producto
+  },
+)
+''',
+        ),
+        ComponentExample(
+          id: 'favorite',
+          title: 'Product Card con Favorito',
+          description: 'Tarjeta de producto marcada como favorita.',
+          previewWidget: _buildFavoriteExample(),
+          codeExample: '''
+ProductCard(
+  imageUrl: 'https://example.com/product.jpg',
+  productName: 'Producto favorito',
+  price: 149.99,
+  rating: 5.0,
+  isFavorite: true,
+  onFavoriteToggle: () {
+    setState(() {
+      _isFavorite = !_isFavorite;
+    });
+  },
+  onCompareDiscounts: () {
+    // Manejar comparación de descuentos
+  },
+  onProductTap: () {
+    // Navegar al detalle del producto
+  },
+)
+''',
+        ),
+        ComponentExample(
+          id: 'grid',
+          title: 'Grid de Product Cards',
+          description: 'Múltiples tarjetas de producto en un grid horizontal.',
+          previewWidget: _buildGridExample(),
+          codeExample: '''
+SizedBox(
+  height: 200,
+  child: ListView.builder(
+    scrollDirection: Axis.horizontal,
+    itemCount: 5,
+    itemBuilder: (context, index) {
+      return ProductCard(
+        imageUrl: 'https://example.com/product\${index + 1}.jpg',
+        productName: 'Producto \${index + 1}',
+        price: 99.99 + (index * 10),
+        rating: 4.0 + (index * 0.2),
+        isFavorite: index % 2 == 0,
+        onFavoriteToggle: () {
+          // Manejar toggle de favorito
+        },
+        onCompareDiscounts: () {
+          // Manejar comparación de descuentos
+        },
+        onProductTap: () {
+          // Navegar al detalle del producto
+        },
+      );
+    },
+  ),
+)
+''',
+        ),
+      ],
+      properties: [
+        ComponentProperty(
+          name: 'imageUrl',
+          type: 'String',
+          description: 'URL de la imagen del producto. Actualmente se usa un placeholder.',
+          required: true,
+        ),
+        ComponentProperty(
+          name: 'productName',
+          type: 'String',
+          description: 'Nombre del producto que se mostrará en la tarjeta.',
+          required: true,
+        ),
+        ComponentProperty(
+          name: 'price',
+          type: 'double',
+          description: 'Precio del producto que se mostrará con formato de moneda.',
+          required: true,
+        ),
+        ComponentProperty(
+          name: 'rating',
+          type: 'double',
+          description: 'Calificación del producto (0.0 a 5.0) que se mostrará como estrellas.',
+          required: false,
+          defaultValue: '5.0',
+        ),
+        ComponentProperty(
+          name: 'isFavorite',
+          type: 'bool',
+          description: 'Estado de favorito del producto que determina el icono del corazón.',
+          required: false,
+          defaultValue: 'false',
+        ),
+        ComponentProperty(
+          name: 'onFavoriteToggle',
+          type: 'VoidCallback?',
+          description: 'Callback que se ejecuta cuando se toca el botón de favorito.',
+          required: false,
+        ),
+        ComponentProperty(
+          name: 'onCompareDiscounts',
+          type: 'VoidCallback?',
+          description: 'Callback que se ejecuta cuando se toca la opción de comparar descuentos.',
+          required: false,
+        ),
+        ComponentProperty(
+          name: 'onProductTap',
+          type: 'VoidCallback?',
+          description: 'Callback que se ejecuta cuando se toca la tarjeta del producto.',
+          required: false,
+        ),
+      ],
+      usageNotes: '''
+## Características del Componente
+
+- **Diseño Responsivo**: La tarjeta tiene dimensiones fijas de 180x180 píxeles optimizadas para grids.
+- **Placeholder de Imagen**: Actualmente usa un placeholder en lugar de cargar imágenes reales.
+- **Interactividad**: Incluye gestos para favorito, comparación de descuentos y navegación al producto.
+- **Estilos Consistentes**: Usa la tipografía InterVariable y colores del sistema de diseño.
+- **Estados Visuales**: Maneja estados de favorito con iconos diferentes.
+
+## Casos de Uso
+
+- **Listas de Productos**: En catálogos y resultados de búsqueda.
+- **Grids de Productos**: En páginas de categorías o recomendaciones.
+- **Carritos de Compras**: Para mostrar productos agregados.
+- **Wishlists**: Para listas de productos favoritos.
+
+## Consideraciones
+
+- El componente está optimizado para mostrar información básica del producto.
+- Para información más detallada, se recomienda navegar a una pantalla de detalle.
+- Los callbacks permiten personalizar la funcionalidad según las necesidades de la aplicación.
+''',
+    );
+  }
+
+  Widget _buildBasicExample() {
+    return Center(
+      child: ProductCard(
+        imageUrl: 'https://example.com/product.jpg',
+        productName: 'Producto de ejemplo',
+        price: 99.99,
+        rating: 4.5,
+        isFavorite: false,
+        onFavoriteToggle: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Favorito toggled')),
+          );
+        },
+        onCompareDiscounts: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Comparar descuentos')),
+          );
+        },
+        onProductTap: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Producto seleccionado')),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildFavoriteExample() {
+    return Center(
+      child: ProductCard(
+        imageUrl: 'https://example.com/product.jpg',
+        productName: 'Producto favorito',
+        price: 149.99,
+        rating: 5.0,
+        isFavorite: true,
+        onFavoriteToggle: () {
+          setState(() {
+            _isFavorite = !_isFavorite;
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Favorito: ${_isFavorite ? 'Agregado' : 'Removido'}')),
+          );
+        },
+        onCompareDiscounts: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Comparar descuentos')),
+          );
+        },
+        onProductTap: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Producto seleccionado')),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildGridExample() {
+    return SizedBox(
+      height: 200,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: 5,
+        itemBuilder: (context, index) {
+          return ProductCard(
+            imageUrl: 'https://example.com/product${index + 1}.jpg',
+            productName: 'Producto ${index + 1}',
+            price: 99.99 + (index * 10),
+            rating: 4.0 + (index * 0.2),
+            isFavorite: index % 2 == 0,
+            onFavoriteToggle: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Favorito toggled en producto ${index + 1}')),
+              );
+            },
+            onCompareDiscounts: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Comparar descuentos del producto ${index + 1}')),
+              );
+            },
+            onProductTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Producto ${index + 1} seleccionado')),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/product_card.dart
+++ b/lib/src/widgets/product_card.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import '../theme/colors/app_colors.dart';
+
+class ProductCard extends StatelessWidget {
+  final String imageUrl;
+  final String productName;
+  final double price;
+  final double rating;
+  final bool isFavorite;
+  final VoidCallback? onFavoriteToggle;
+  final VoidCallback? onCompareDiscounts;
+  final VoidCallback? onProductTap;
+
+  const ProductCard({
+    super.key,
+    required this.imageUrl,
+    required this.productName,
+    required this.price,
+    this.rating = 5.0,
+    this.isFavorite = false,
+    this.onFavoriteToggle,
+    this.onCompareDiscounts,
+    this.onProductTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onProductTap,
+      child: Container(
+        width: 180,
+        height: 180,
+        margin: const EdgeInsets.only(
+          right: 20.0,
+          left: 4.0,
+          top: 4.0,
+          bottom: 4.0,
+        ),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 4,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          children: [
+            // Imagen del producto en la parte superior
+            Expanded(
+              flex: 2,
+              child: Stack(
+                children: [
+                  // Fondo blanco para la imagen
+                  Container(
+                    width: double.infinity,
+                    height: double.infinity,
+                    decoration: const BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(12.0),
+                        topRight: Radius.circular(12.0),
+                      ),
+                    ),
+                  ),
+                  // Placeholder en lugar de imagen
+                  ClipRRect(
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(12.0),
+                      topRight: Radius.circular(12.0),
+                    ),
+                    child: Container(
+                      width: double.infinity,
+                      height: 150,
+                      color: Colors.white,
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.inventory,
+                              size: 40,
+                              color: AppColors.grayMedium,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Imagen del producto',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.grayMedium,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  // Botón de favorito (like) superpuesto en la esquina superior derecha
+                  Positioned(
+                    top: 8.0,
+                    right: 8.0,
+                    child: Container(
+                      padding: const EdgeInsets.all(4.0),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        shape: BoxShape.circle,
+                      ),
+                      child: _FavoriteIcon(
+                        isFavorite: isFavorite,
+                        size: 18.0,
+                        onPressed: onFavoriteToggle,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Información del producto en la parte inferior
+            Container(
+              height: 130,
+              decoration: const BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.only(
+                  bottomLeft: Radius.circular(12.0),
+                  bottomRight: Radius.circular(12.0),
+                ),
+              ),
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  // Estrellas de rating
+                  _RatingStars(
+                    rating: rating,
+                    size: 13.0,
+                    gap: 2.0,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                  ),
+
+                  const SizedBox(height: 4.0),
+
+                  // Nombre del producto (máximo 2 líneas)
+                  Text(
+                    productName,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 16.0,
+                      fontFamily: 'InterVariable',
+                      fontWeight: FontWeight.w900,
+                      fontFeatures: [FontFeature('ss01'), FontFeature('cv11')],
+                      color: AppColors.black,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+
+                  const SizedBox(height: 4.0),
+
+                  // Precio y etiqueta "Público"
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '\$${price.toStringAsFixed(2)}',
+                        style: const TextStyle(
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.w900,
+                          fontFeatures: [
+                            FontFeature('ss01'),
+                            FontFeature('cv11'),
+                          ],
+                          color: AppColors.orangeBrand,
+                        ),
+                      ),
+                      const SizedBox(width: 6.0),
+                      Text(
+                        'Público',
+                        style: TextStyle(
+                          fontSize: 12.0,
+                          color: AppColors.orangeBrand,
+                          fontWeight: FontWeight.w400,
+                          fontFeatures: [
+                            FontFeature('ss01'),
+                            FontFeature('cv11'),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 4.0),
+
+                  // Opción de comparar descuentos con icono de info
+                  GestureDetector(
+                    onTap: onCompareDiscounts,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          'COMPARAR DESCUENTOS',
+                          style: TextStyle(
+                            fontSize: 9.0,
+                            color: AppColors.darkGray,
+                            fontWeight: FontWeight.w500,
+                            fontFeatures: [
+                              FontFeature('ss01'),
+                              FontFeature('cv11'),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 4.0),
+                        Icon(
+                          Icons.info_outline,
+                          size: 12,
+                          color: AppColors.darkGray,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// Widget interno para el icono de favorito
+class _FavoriteIcon extends StatelessWidget {
+  final bool isFavorite;
+  final double size;
+  final VoidCallback? onPressed;
+
+  const _FavoriteIcon({
+    required this.isFavorite,
+    required this.size,
+    this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onPressed,
+      child: Icon(
+        isFavorite ? Icons.favorite : Icons.favorite_border,
+        size: size,
+        color: isFavorite ? AppColors.digitalRed : AppColors.grayMedium,
+      ),
+    );
+  }
+}
+
+// Widget interno para las estrellas de rating
+class _RatingStars extends StatelessWidget {
+  final double rating;
+  final double size;
+  final double gap;
+  final MainAxisAlignment mainAxisAlignment;
+
+  const _RatingStars({
+    required this.rating,
+    required this.size,
+    required this.gap,
+    required this.mainAxisAlignment,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: mainAxisAlignment,
+      children: List.generate(5, (index) {
+        final starValue = index + 1;
+        final isFilled = starValue <= rating;
+        final isHalfFilled = starValue - 0.5 <= rating && starValue > rating;
+
+        return Padding(
+          padding: EdgeInsets.only(right: index < 4 ? gap : 0),
+          child: Icon(
+            isFilled
+                ? Icons.star
+                : isHalfFilled
+                    ? Icons.star_half
+                    : Icons.star_border,
+            size: size,
+            color: AppColors.orangeBrand,
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -2,6 +2,7 @@
 export 'buttons/ui_button.dart';
 export 'inputs/app_text_field.dart';
 export 'custom_svg_icon.dart';
+export 'product_card.dart';
 
 // Navigation widgets
 export 'navigation/mobile_navigation.dart';
@@ -33,5 +34,6 @@ export 'component_content/typography_content.dart';
 export 'component_content/z_index_content.dart';
 export 'component_content/screen_template.dart';
 export 'component_content/example_usage_template.dart';
+export 'component_content/product_card_content.dart';
 export 'tabs_widget.dart';
 export 'badge_widget.dart'; 


### PR DESCRIPTION
- Introduced `ProductCard` widget for displaying product information including image, name, price, rating, and favorite status.
- Created `ProductCardContent` for showcasing examples and usage of the `ProductCard`.
- Updated `DesignSystemData` to include the new `Product Card` navigation item.
- Exported `ProductCard` and `ProductCardContent` in the main widgets file for easy access.