### PR TITLE
feat: Add guidelines for creating reusable widgets

### DIFF
--- a/.cursor/rules/reglas-package-app-mayoreo.mdc
+++ b/.cursor/rules/reglas-package-app-mayoreo.mdc
@@ -1,0 +1,15 @@
+---
+Cuando crees un nuevo widget reutilizable en lib/src/widgets/ (por ejemplo, ComponentX):
+
+- Exporta el widget en lib/src/widgets/widgets.dart sin duplicados.
+- Crea su pantalla de documentación en lib/src/widgets/component_content/ComponentX_content.dart usando ComponentScreenTemplate y ejemplos mínimos de uso real.
+- Registra el componente en lib/src/data/design_system_data.dart (lista uiComponents o designGuides según corresponda):
+  - id: en kebab-case del nombre (p. ej., component-x).
+  - title: nombre legible (p. ej., Component X).
+  - description: breve y clara (1 línea).
+  - icon: usa un Icons.* apropiado.
+  - content: ComponentXContent() con la import correspondiente.
+  - Mantén el orden y estilo existentes; no dupliques entradas.
+- Asegura imports necesarios y evita exportaciones repetidas.
+- Ejecuta una revisión de lints de los archivos tocados y corrige warnings/errores obvios.
+---


### PR DESCRIPTION
- Introduced a new markdown file with detailed instructions for creating reusable widgets in the project.
- Included steps for exporting widgets, creating documentation screens, and registering components in the design system.
- Emphasized the importance of maintaining existing order and style, as well as ensuring proper imports and linting.