### PR TITLE
feat: Add reusable ComponentCard and ContentAppBar components

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,26 @@
+### Regla: Auto-registrar nuevos widgets de componentes
+
+Cuando crees un nuevo widget reutilizable en `lib/src/widgets/` (por ejemplo, `ComponentX`):
+
+- Exporta el widget en `lib/src/widgets/widgets.dart` sin duplicados.
+- Crea su pantalla de documentación en `lib/src/widgets/component_content/ComponentX_content.dart` usando `ComponentScreenTemplate` y ejemplos mínimos de uso real.
+- Registra el componente en `lib/src/data/design_system_data.dart` (lista `uiComponents` o `designGuides` según corresponda):
+  - `id`: en kebab-case del nombre (p. ej., `component-x`).
+  - `title`: nombre legible (p. ej., `Component X`).
+  - `description`: breve y clara (1 línea).
+  - `icon`: usa un `Icons.*` apropiado.
+  - `content`: `ComponentXContent()` con la import correspondiente.
+  - Mantén el orden y estilo existentes; no dupliques entradas.
+- Asegura imports necesarios y evita exportaciones repetidas.
+- Ejecuta una revisión de lints de los archivos tocados y corrige warnings/errores obvios.
+
+Restricciones de iconos y estilo:
+- Usa solo iconos del proyecto con `SafeSvgIcon` cuando aplique y respeta los assets declarados.
+- Mantén el estilo visual existente (bordes, sombras, tipografías, colores `AppColors`).
+
+Buenas prácticas:
+- Propiedades claras y tipadas; evita abreviaturas en nombres.
+- Ejemplos de uso concisos y funcionales, relacionados con la vista previa.
+- No crear archivos de test nuevos; usa los existentes si aplica.
+
+

--- a/example/lib/screens/components_summary_screen.dart
+++ b/example/lib/screens/components_summary_screen.dart
@@ -217,7 +217,8 @@ class _ComponentsSummaryScreenState extends State<ComponentsSummaryScreen> {
   }
 
   Widget _buildComponentCard(NavigationItem component) {
-    return GestureDetector(
+    return ComponentCard(
+      component: component,
       onTap: () {
         Navigator.of(context).push(
           MaterialPageRoute(
@@ -225,157 +226,10 @@ class _ComponentsSummaryScreenState extends State<ComponentsSummaryScreen> {
           ),
         );
       },
-      child: Container(
-        decoration: BoxDecoration(
-          color: AppColors.white,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: AppColors.grayMedium.withValues(alpha: 0.2),
-            width: 1,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: AppColors.black.withValues(alpha: 0.05),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Icon and Category Badge
-              Row(
-                children: [
-                  _buildComponentIcon(component),
-                  const Spacer(),
-                  _buildCategoryBadge(component.category),
-                ],
-              ),
-              const SizedBox(height: 16),
-              // Title
-              Text(
-                component.title,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.black,
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: 8),
-              // Description
-              Expanded(
-                child: Text(
-                  component.description,
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppColors.darkGray,
-                    height: 1.4,
-                  ),
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const SizedBox(height: 16),
-              // CTA Button
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => ComponentDetailScreen(component: component),
-                      ),
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.orangeBrand,
-                    foregroundColor: AppColors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    elevation: 0,
-                  ),
-                  child: const Text(
-                    'Ver Detalles',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 
-  Widget _buildComponentIcon(NavigationItem component) {
-    return Container(
-      width: 40,
-      height: 40,
-      decoration: BoxDecoration(
-        color: component.category == NavigationCategory.designGuides
-            ? AppColors.orangeBrand.withValues(alpha: 0.1)
-            : AppColors.greenFree.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: Center(
-        child: component.iconType == IconType.material
-            ? Icon(
-                component.icon,
-                size: 20,
-                color: component.category == NavigationCategory.designGuides
-                    ? AppColors.orangeBrand
-                    : AppColors.greenFree,
-              )
-            : Icon(
-                Icons.widgets,
-                size: 20,
-                color: component.category == NavigationCategory.designGuides
-                    ? AppColors.orangeBrand
-                    : AppColors.greenFree,
-              ),
-      ),
-    );
-  }
-
-  Widget _buildCategoryBadge(NavigationCategory category) {
-    final categoryText = category == NavigationCategory.designGuides
-        ? 'Guía'
-        : 'UI';
-    
-    final categoryColor = category == NavigationCategory.designGuides
-        ? AppColors.orangeBrand
-        : AppColors.greenFree;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: categoryColor.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: categoryColor.withValues(alpha: 0.3),
-          width: 1,
-        ),
-      ),
-      child: Text(
-        categoryText,
-        style: TextStyle(
-          fontSize: 10,
-          fontWeight: FontWeight.w600,
-          color: categoryColor,
-        ),
-      ),
-    );
-  }
+  // Eliminado: icono y badge individuales ahora los maneja ComponentCard
 
   Widget _buildEmptyState() {
     return Center(

--- a/example/lib/screens/icons_screen.dart
+++ b/example/lib/screens/icons_screen.dart
@@ -190,7 +190,7 @@ class _IconsScreenState extends State<IconsScreen> {
               ),
               const SizedBox(width: 8),
               Text(
-                'PackageIcon (Material Design Style) - $totalIconCount iconos',
+                'PackageIcon - $totalIconCount iconos',
                 style: AppTypography.bodySmall?.copyWith(
                   color: AppColors.grayMedium,
                 ) ?? TextStyle(

--- a/lib/src/data/design_system_data.dart
+++ b/lib/src/data/design_system_data.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/navigation_item.dart';
+import '../widgets/component_content/component_card_content.dart';
 import '../widgets/component_content/colors_content.dart';
 import '../widgets/component_content/typography_content.dart';
 import '../widgets/component_content/buttons_content.dart';
@@ -18,6 +19,7 @@ import '../widgets/component_content/breadcrumbs_content.dart';
 import '../widgets/component_content/search_bar_content.dart';
 import '../widgets/component_content/bottom_navigation_content.dart';
 import '../widgets/component_content/tabs_content.dart';
+import '../widgets/component_content/content_app_bar_content.dart';
 
 class DesignSystemData {
   static const List<NavigationItem> designGuides = [
@@ -102,6 +104,22 @@ class DesignSystemData {
   ];
 
   static const List<NavigationItem> uiComponents = [
+    NavigationItem.material(
+      id: 'content-app-bar',
+      title: 'Content App Bar',
+      description: 'App bar unificado con back, título y sugerencia UX',
+      icon: Icons.arrow_back,
+      category: NavigationCategory.uiComponents,
+      content: ContentAppBarContent(),
+    ),
+    NavigationItem.material(
+      id: 'component-card',
+      title: 'Component Card',
+      description: 'Card reutilizable para listar componentes',
+      icon: Icons.view_agenda,
+      category: NavigationCategory.uiComponents,
+      content: ComponentCardContent(),
+    ),
     NavigationItem.material(
       id: 'buttons',
       title: 'Botones',

--- a/lib/src/widgets/component_card.dart
+++ b/lib/src/widgets/component_card.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_package_app_mayoreo/flutter_package_app_mayoreo.dart';
+
+/// Card reutilizable para listar componentes del Design System.
+/// Replica el diseño utilizado en `ComponentsSummaryScreen`.
+class ComponentCard extends StatelessWidget {
+  final NavigationItem component;
+  final VoidCallback? onTap;
+  final String ctaText;
+  final bool showCtaButton;
+
+  const ComponentCard({
+    super.key,
+    required this.component,
+    this.onTap,
+    this.ctaText = 'Ver Detalles',
+    this.showCtaButton = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: AppColors.grayMedium.withValues(alpha: 0.2),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.black.withValues(alpha: 0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _buildComponentIcon(),
+                  const Spacer(),
+                  _buildCategoryBadge(),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(
+                component.title,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.black,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: Text(
+                  component.description,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: AppColors.darkGray,
+                    height: 1.4,
+                  ),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (showCtaButton) ...[
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: onTap,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.orangeBrand,
+                      foregroundColor: AppColors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      elevation: 0,
+                    ),
+                    child: Text(
+                      ctaText,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComponentIcon() {
+    final bool isGuide = component.category == NavigationCategory.designGuides;
+    final Color accent = isGuide ? AppColors.orangeBrand : AppColors.greenFree;
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Center(
+        child: component.iconType == IconType.svg && component.svgIcon != null
+            ? SafeSvgIcon(
+                iconPath: component.svgIcon!,
+                height: 20,
+                color: accent,
+              )
+            : Icon(
+                component.icon ?? Icons.widgets,
+                size: 20,
+                color: accent,
+              ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryBadge() {
+    final bool isGuide = component.category == NavigationCategory.designGuides;
+    final String categoryText = isGuide ? 'Guía' : 'UI';
+    final Color accent = isGuide ? AppColors.orangeBrand : AppColors.greenFree;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: accent.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Text(
+        categoryText,
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: accent,
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/src/widgets/component_content/component_card_content.dart
+++ b/lib/src/widgets/component_content/component_card_content.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_package_app_mayoreo/flutter_package_app_mayoreo.dart';
+
+class ComponentCardContent extends StatelessWidget {
+  const ComponentCardContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ComponentScreenTemplate(
+      componentTitle: 'ComponentCard',
+      componentDescription: 'Card reutilizable para listar componentes en grillas o listas, replicando el estilo usado en la pantalla de resumen de componentes.',
+      examples: [
+        ComponentExample(
+          id: 'basic_card',
+          title: 'Uso básico',
+          description: 'Card con título, descripción, icono y badge de categoría. Incluye CTA.',
+          previewWidget: _PreviewBasic(),
+          codeExample: '''ComponentCard(
+  component: NavigationItem.material(
+    id: 'buttons',
+    title: 'Botones',
+    description: 'Sistema de botones interactivos',
+    icon: Icons.touch_app,
+    category: NavigationCategory.uiComponents,
+  ),
+  onTap: () {},
+  ctaText: 'Ver Detalles',
+  showCtaButton: true,
+)''',
+        ),
+        ComponentExample(
+          id: 'without_cta',
+          title: 'Card sin botón CTA',
+          description: 'Para listados donde el tap en toda el área ya navega.',
+          previewWidget: _PreviewWithoutCta(),
+          codeExample: '''ComponentCard(
+  component: NavigationItem.material(
+    id: 'typography',
+    title: 'Tipografía',
+    description: 'Sistema de tipografía con Inter',
+    icon: Icons.text_fields,
+    category: NavigationCategory.designGuides,
+  ),
+  onTap: () {},
+  showCtaButton: false,
+)''',
+        ),
+      ],
+      properties: const [
+        ComponentProperty(
+          name: 'component',
+          type: 'NavigationItem',
+          description: 'Modelo del componente a representar (título, descripción, icono, categoría).',
+          required: true,
+        ),
+        ComponentProperty(
+          name: 'onTap',
+          type: 'VoidCallback?',
+          description: 'Callback al tocar la card o el botón CTA.',
+        ),
+        ComponentProperty(
+          name: 'ctaText',
+          type: 'String',
+          description: 'Texto del botón de llamada a la acción.',
+          defaultValue: 'Ver Detalles',
+        ),
+        ComponentProperty(
+          name: 'showCtaButton',
+          type: 'bool',
+          description: 'Si muestra o no el botón CTA inferior.',
+          defaultValue: 'true',
+        ),
+      ],
+      methods: const [],
+      usageNotes: 'Use ComponentCard en grillas (childAspectRatio ≈ 0.85) o listas. Para iconos SVG, configure NavigationItem.svg y se renderiza con SafeSvgIcon.',
+    );
+  }
+}
+
+class _PreviewBasic extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 280,
+      height: 220,
+      child: ComponentCard(
+        component: const NavigationItem.material(
+          id: 'buttons',
+          title: 'Botones',
+          description: 'Sistema de botones interactivos',
+          icon: Icons.touch_app,
+          category: NavigationCategory.uiComponents,
+        ),
+        onTap: () {},
+      ),
+    );
+  }
+}
+
+class _PreviewWithoutCta extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 280,
+      height: 200,
+      child: ComponentCard(
+        component: const NavigationItem.material(
+          id: 'typography',
+          title: 'Tipografía',
+          description: 'Sistema de tipografía con Inter',
+          icon: Icons.text_fields,
+          category: NavigationCategory.designGuides,
+        ),
+        onTap: () {},
+        showCtaButton: false,
+      ),
+    );
+  }
+}
+
+

--- a/lib/src/widgets/component_content/content_app_bar_content.dart
+++ b/lib/src/widgets/component_content/content_app_bar_content.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_package_app_mayoreo/flutter_package_app_mayoreo.dart';
+
+class ContentAppBarContent extends StatelessWidget {
+  const ContentAppBarContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ComponentScreenTemplate(
+      componentTitle: 'ContentAppBar',
+      componentDescription: 'App bar unificado para pantallas de contenido con botón de retroceso, título y sugerencia UX opcional.',
+      examples: const [
+        ComponentExample(
+          id: 'basic',
+          title: 'Uso básico',
+          description: 'Título y botón de retroceso por defecto.',
+          previewWidget: _PreviewBasic(),
+          codeExample: '''Scaffold(
+  appBar: ContentAppBar(
+    title: 'Componentes',
+  ),
+  body: ...,
+)''',
+        ),
+        ComponentExample(
+          id: 'with_hint',
+          title: 'Con sugerencia UX',
+          description: 'Muestra un chip informativo bajo el título.',
+          previewWidget: _PreviewWithHint(),
+          codeExample: '''Scaffold(
+  appBar: ContentAppBar(
+    title: 'Botones',
+    hintText: 'Sugerencia: usa títulos claros y concisos.',
+  ),
+  body: ...,
+)''',
+        ),
+      ],
+      properties: const [
+        ComponentProperty(
+          name: 'title',
+          type: 'String',
+          description: 'Título mostrado en el app bar.',
+          required: true,
+        ),
+        ComponentProperty(
+          name: 'hintText',
+          type: 'String?',
+          description: 'Texto de sugerencia UX opcional mostrado bajo el título.',
+        ),
+        ComponentProperty(
+          name: 'onBack',
+          type: 'VoidCallback?',
+          description: 'Callback para el botón de retroceso. Por defecto usa Navigator.maybePop.',
+        ),
+        ComponentProperty(
+          name: 'actions',
+          type: 'List<Widget>?',
+          description: 'Acciones a la derecha del app bar.',
+        ),
+        ComponentProperty(
+          name: 'showDivider',
+          type: 'bool',
+          description: 'Muestra un separador inferior sutil.',
+          defaultValue: 'true',
+        ),
+        ComponentProperty(
+          name: 'backgroundColor',
+          type: 'Color?',
+          description: 'Color de fondo. Por defecto usa theme.colorScheme.surface.',
+        ),
+      ],
+      methods: const [],
+      usageNotes: 'Ideal para pantallas de documentación de componentes. Mantén la sugerencia breve y accionable.',
+    );
+  }
+}
+
+class _PreviewBasic extends StatelessWidget {
+  const _PreviewBasic();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: kToolbarHeight,
+      child: const ContentAppBar(title: 'Componentes'),
+    );
+  }
+}
+
+class _PreviewWithHint extends StatelessWidget {
+  const _PreviewWithHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: kToolbarHeight + 36,
+      child: const ContentAppBar(
+        title: 'Botones',
+        hintText: 'Sugerencia: usa títulos claros y concisos.',
+      ),
+    );
+  }
+}
+
+

--- a/lib/src/widgets/content_app_bar.dart
+++ b/lib/src/widgets/content_app_bar.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_package_app_mayoreo/flutter_package_app_mayoreo.dart';
+
+/// App bar unificado para pantallas de contenido de widgets.
+/// Incluye botón de retroceso, título y una sugerencia UX opcional.
+class ContentAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final String? hintText;
+  final VoidCallback? onBack;
+  final List<Widget>? actions;
+  final bool showDivider;
+  final Color? backgroundColor;
+
+  const ContentAppBar({
+    super.key,
+    required this.title,
+    this.hintText,
+    this.onBack,
+    this.actions,
+    this.showDivider = true,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color bg = backgroundColor ?? theme.colorScheme.surface;
+
+    return AppBar(
+      titleSpacing: 0,
+      backgroundColor: bg,
+      elevation: 0,
+      leading: _buildBackButton(context),
+      title: Text(
+        title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+          color: AppColors.black,
+        ),
+      ),
+      actions: actions,
+      bottom: PreferredSize(
+        preferredSize: Size.fromHeight(_bottomHeight(theme)),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (hintText != null) _buildHint(theme),
+            if (showDivider)
+              Container(
+                height: 1,
+                color: theme.colorScheme.outline.withValues(alpha: 0.2),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBackButton(BuildContext context) {
+    return IconButton(
+      tooltip: 'Volver',
+      onPressed: onBack ?? () => Navigator.maybePop(context),
+      icon: const SafeSvgIcon(
+        iconPath: PackageIcons.arrowLeft,
+        height: 20,
+      ),
+    );
+  }
+
+  Widget _buildHint(ThemeData theme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.softGray,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: AppColors.grayMedium.withValues(alpha: 0.2),
+          ),
+        ),
+        child: Row(
+          children: [
+            const SafeSvgIcon(
+              iconPath: PackageIcons.alertIcon,
+              height: 16,
+              color: AppColors.grayMedium,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                hintText!,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AppColors.darkGray,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double _bottomHeight(ThemeData theme) {
+    double height = 0;
+    if (hintText != null) {
+      height += 8 + 8 + 16; // padding + chip height approx
+    }
+    if (showDivider) height += 1;
+    return height;
+  }
+
+  @override
+  Size get preferredSize {
+    // kToolbarHeight + bottom preferred size
+    final double bottom = (hintText != null ? 32 : 0) + (showDivider ? 1 : 0);
+    return Size.fromHeight(kToolbarHeight + bottom);
+  }
+}
+
+

--- a/lib/src/widgets/navigation/mobile_navigation.dart
+++ b/lib/src/widgets/navigation/mobile_navigation.dart
@@ -55,15 +55,15 @@ class _MobileNavigationState extends State<MobileNavigation> {
                 onTap: () => widget.onItemTapped(1),
               ),
               _buildNavigationItem(
-                icon: PackageIcons.documentInactive,
-                activeIcon: PackageIcons.documentActive,
+                icon: PackageIcons.icon,
+                activeIcon: PackageIcons.icon,
                 label: 'Iconos',
                 isSelected: widget.selectedIndex == 2,
                 onTap: () => widget.onItemTapped(2),
               ),
               _buildNavigationItem(
-                icon: PackageIcons.helpInactive,
-                activeIcon: PackageIcons.helpActive,
+                icon: PackageIcons.documentInactive,
+                activeIcon: PackageIcons.documentActive,
                 label: 'Docs',
                 isSelected: widget.selectedIndex == 3,
                 onTap: () => widget.onItemTapped(3),
@@ -83,27 +83,31 @@ class _MobileNavigationState extends State<MobileNavigation> {
     required bool isSelected,
     required VoidCallback onTap,
   }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Icono simple
-          SafeSvgIcon(
-            iconPath: isSelected ? activeIcon : icon,
-            height: 24,
+    return Expanded(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SafeSvgIcon(
+                iconPath: isSelected ? activeIcon : icon,
+                height: 24,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                  color: isSelected ? AppColors.orangeBrand : AppColors.grayMedium,
+                ),
+              ),
+            ],
           ),
-          const SizedBox(height: 4),
-          // Etiqueta
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 10,
-              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-              color: isSelected ? AppColors.orangeBrand : AppColors.grayMedium,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -12,6 +12,7 @@ export 'app_bar_widget.dart';
 export 'search_bar_widget.dart';
 export 'search_results_widget.dart';
 export 'mobile_card.dart';
+export 'component_card.dart';
 
 // Component content widgets
 export 'component_content/accordion_content.dart';
@@ -35,3 +36,6 @@ export 'component_content/screen_template.dart';
 export 'component_content/example_usage_template.dart';
 export 'tabs_widget.dart';
 export 'badge_widget.dart'; 
+export 'component_content/component_card_content.dart';
+export 'content_app_bar.dart';
+export 'component_content/content_app_bar_content.dart';


### PR DESCRIPTION
- Introduced `ComponentCard` for displaying components in a consistent card format, including icon and category badge.
- Added `ContentAppBar` for unified app bar design with back navigation and optional UX hints.
- Created corresponding content screens for both components to provide usage examples and documentation.
- Updated `design_system_data.dart` to register new components and ensure proper integration.
- Enhanced `widgets.dart` to export new components and maintain organization.
- Added linting rules and documentation for new widget creation.